### PR TITLE
Monitor script failing if more than one USB ports are found

### DIFF
--- a/Support/Monitor
+++ b/Support/Monitor
@@ -1,7 +1,7 @@
 #!/bin/bash
-
+set -- /dev/*usb*
 # make sure there's a usb port
-if [ -d /dev/*usb* ]; then
+if [ -r "$1" ]; then
   
   # get the list of USB ports
   dev_list=(`ls /dev/*usb*`)


### PR DESCRIPTION
Fixed the Monitor shell script to check for any number of URB ports
