### PR TITLE
Fixed duplicate periods in front of pde file extension in save dialogs

### DIFF
--- a/Syntaxes/Arduino.tmLanguage
+++ b/Syntaxes/Arduino.tmLanguage
@@ -4,7 +4,7 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string>.pde</string>
+		<string>pde</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>/\*\*|\{\s*$</string>


### PR DESCRIPTION
No period needed in the fileTypes string; results in duplicates in save dialogs ("Arduino..pde").

TextMate Version 1.5.10 (1623)
