### PR TITLE
Fixed edge case in the sed inside Show Assembly

### DIFF
--- a/Commands/Show Assembly.tmCommand
+++ b/Commands/Show Assembly.tmCommand
@@ -7,7 +7,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
-TM_FILENAME_NO_EXT=$(echo $TM_FILENAME | sed /.ino/s///)
+TM_FILENAME_NO_EXT=$(echo $TM_FILENAME | sed /\.ino$/s///)
 
 /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/avr-objdump -d $TM_DIRECTORY/applet/$TM_FILENAME_NO_EXT.elf</string>
 	<key>input</key>


### PR DESCRIPTION
Fixed the sed expression to correctly remove the .ino extension. The
previous would fail if TM_FILENAME contained an 'ino' in the name
(Example: phoduino.ino would incorrectly yield phod.ino
