### PR TITLE
Fixed escape problem with "Watch Serial Port" command

### DIFF
--- a/Commands/Watch serial port.tmCommand
+++ b/Commands/Watch serial port.tmCommand
@@ -5,7 +5,8 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>osascript -e 'tell application "Terminal" to do script "\"${TM_BUNDLE_SUPPORT}/Monitor\""'</string>
+	<string>TM_BUNDLE_SUPPORT_ESC=$(echo $TM_BUNDLE_SUPPORT | sed '/Support/s/ /\\\\ /')
+ osascript -e "tell application \"Terminal\" to do script \"${TM_BUNDLE_SUPPORT_ESC}/Monitor\""</string>
 	<key>input</key>
 	<string>none</string>
 	<key>name</key>


### PR DESCRIPTION
Fixed the problem with not escaping the space in "Application Support"
